### PR TITLE
Fix/php8 deprecation notices

### DIFF
--- a/ModularContent/AdminPreCache.php
+++ b/ModularContent/AdminPreCache.php
@@ -63,10 +63,10 @@ class AdminPreCache implements \JsonSerializable {
 	 * Specify data which should be serialized to JSON
 	 *
 	 * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
-	 * @return mixed data which can be serialized by <b>json_encode</b>,
+	 * @return array data which can be serialized by <b>json_encode</b>,
 	 * which is a value of any type other than a resource.
 	 */
-	public function jsonSerialize() {
+	public function jsonSerialize(): array {
 		return $this->get_cache();
 	}
 

--- a/ModularContent/Blueprint_Builder.php
+++ b/ModularContent/Blueprint_Builder.php
@@ -92,7 +92,7 @@ class Blueprint_Builder implements \JsonSerializable {
 		return $children;
 	}
 
-	public function jsonSerialize() {
+	public function jsonSerialize(): array {
 		$type = $this->get_current_post_type();
 		$blueprint = $this->get_blueprint( $type );
 		foreach ( $blueprint[ 'types' ] as $index => $panel ) {

--- a/ModularContent/Panel.php
+++ b/ModularContent/Panel.php
@@ -110,7 +110,7 @@ class Panel implements \JsonSerializable {
 		return $this->children;
 	}
 
-	public function jsonSerialize() {
+	public function jsonSerialize(): array {
 		return [
 			'type'   => (string) $this->type,
 			'depth'  => (int) $this->depth,

--- a/ModularContent/PanelCollection.php
+++ b/ModularContent/PanelCollection.php
@@ -83,7 +83,7 @@ class PanelCollection implements \JsonSerializable {
 		return $loop->render();
 	}
 
-	public function jsonSerialize() {
+	public function jsonSerialize(): array {
 		return array(
 			'panels' => $this->panels,
 		);

--- a/ModularContent/Sets/Panel_Set_Meta_Box.php
+++ b/ModularContent/Sets/Panel_Set_Meta_Box.php
@@ -16,6 +16,7 @@ abstract class Panel_Set_Meta_Box {
 	protected $meta_box_defaults;
 
 	private static $registry = [ ];
+	private $post_type;
 
 	public static function init() {
 		add_action( 'post_submitbox_misc_actions', [ __CLASS__, 'display_nonce' ] );

--- a/ModularContent/Sets/Set.php
+++ b/ModularContent/Sets/Set.php
@@ -24,10 +24,10 @@ class Set implements \JsonSerializable {
 	 * Specify data which should be serialized to JSON
 	 *
 	 * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
-	 * @return mixed data which can be serialized by <b>json_encode</b>,
+	 * @return array data which can be serialized by <b>json_encode</b>,
 	 * which is a value of any type other than a resource.
 	 */
-	public function jsonSerialize() {
+	public function jsonSerialize(): array {
 		return [
 			'id'          => $this->post_id,
 			'label'       => $this->get_label(),


### PR DESCRIPTION
A couple small change to prevent deprecation notices:
* Make return types match abstract.
* Add missing private property.